### PR TITLE
feat: CLI強化 & slog移行 (Task 17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 EPUB to AZW3 converter - a standalone Go implementation for converting EPUB ebooks to Amazon Kindle compatible AZW3 (KF8) format without external dependencies like Calibre.
 
+## Usage
+
+```bash
+epub2azw3 [flags] <input.epub>
+```
+
+### Flags
+
+- `-o, --output`: output file path (default: `<input>.azw3`)
+- `-q, --quality`: JPEG quality (`60-100`, default: `85`)
+- `--max-image-size`: max image size in KB (default: `127`)
+- `--max-image-width`: max image width in px (default: `600`)
+- `--no-images`: remove all images from output
+- `-l, --log-level`: `error|warn|info|debug` (default: `info`)
+- `--log-format`: `text|json` (default: `text`)
+- `--strict`: treat recoverable warnings as errors
+- `-v, --verbose`: enable verbose output (forces debug logging)
+
 ## Development
 
 ### Build

--- a/cmd/epub2azw3/main.go
+++ b/cmd/epub2azw3/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,45 +12,184 @@ import (
 	"github.com/yuanying/epub2azw3/internal/converter"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "epub2azw3",
-	Short: "Convert EPUB files to AZW3 (Kindle) format",
-	Long: `epub2azw3 is a command-line tool that converts EPUB ebooks to
+const (
+	defaultJPEGQuality   = 85
+	defaultMaxImageSize  = 127
+	defaultMaxImageWidth = 600
+)
+
+type CLIOptions struct {
+	OutputPath    string
+	JPEGQuality   int
+	MaxImageSize  int
+	MaxImageWidth int
+	NoImages      bool
+	LogLevel      string
+	LogFormat     string
+	Strict        bool
+	Verbose       bool
+}
+
+func normalizeLogLevel(level string, verbose bool) string {
+	normalized := strings.ToLower(strings.TrimSpace(level))
+	if normalized == "" {
+		normalized = "info"
+	}
+	if verbose {
+		return "debug"
+	}
+	return normalized
+}
+
+func defaultOutputPath(inputPath string) string {
+	return strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + ".azw3"
+}
+
+func validateCLIOptions(opts CLIOptions) error {
+	if opts.JPEGQuality < 60 || opts.JPEGQuality > 100 {
+		return fmt.Errorf("invalid --quality %d (expected 60-100)", opts.JPEGQuality)
+	}
+	if opts.MaxImageSize <= 0 {
+		return fmt.Errorf("invalid --max-image-size %d (expected > 0)", opts.MaxImageSize)
+	}
+	if opts.MaxImageWidth <= 0 {
+		return fmt.Errorf("invalid --max-image-width %d (expected > 0)", opts.MaxImageWidth)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(opts.LogLevel)) {
+	case "error", "warn", "info", "debug":
+	default:
+		return fmt.Errorf("invalid --log-level %q (expected error/warn/info/debug)", opts.LogLevel)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(opts.LogFormat)) {
+	case "text", "json":
+	default:
+		return fmt.Errorf("invalid --log-format %q (expected text/json)", opts.LogFormat)
+	}
+
+	return nil
+}
+
+func parseSlogLevel(s string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "error":
+		return slog.LevelError
+	case "warn":
+		return slog.LevelWarn
+	case "debug":
+		return slog.LevelDebug
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func buildLogger(writer io.Writer, levelStr string, format string) *slog.Logger {
+	level := parseSlogLevel(levelStr)
+	format = strings.ToLower(strings.TrimSpace(format))
+	removeTime := func(groups []string, a slog.Attr) slog.Attr {
+		if a.Key == slog.TimeKey && len(groups) == 0 {
+			return slog.Attr{}
+		}
+		return a
+	}
+	var handler slog.Handler
+	switch format {
+	case "json":
+		handler = slog.NewJSONHandler(writer, &slog.HandlerOptions{Level: level})
+	default:
+		handler = slog.NewTextHandler(writer, &slog.HandlerOptions{
+			Level:       level,
+			ReplaceAttr: removeTime,
+		})
+	}
+	return slog.New(handler)
+}
+
+func readCLIOptions(cmd *cobra.Command, args []string) (converter.ConvertOptions, error) {
+	inputPath := args[0]
+
+	outputPath, _ := cmd.Flags().GetString("output")
+	quality, _ := cmd.Flags().GetInt("quality")
+	maxImageSize, _ := cmd.Flags().GetInt("max-image-size")
+	maxImageWidth, _ := cmd.Flags().GetInt("max-image-width")
+	noImages, _ := cmd.Flags().GetBool("no-images")
+	logLevel, _ := cmd.Flags().GetString("log-level")
+	logFormat, _ := cmd.Flags().GetString("log-format")
+	strict, _ := cmd.Flags().GetBool("strict")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	cliOpts := CLIOptions{
+		OutputPath:    outputPath,
+		JPEGQuality:   quality,
+		MaxImageSize:  maxImageSize,
+		MaxImageWidth: maxImageWidth,
+		NoImages:      noImages,
+		LogLevel:      normalizeLogLevel(logLevel, verbose),
+		LogFormat:     logFormat,
+		Strict:        strict,
+		Verbose:       verbose,
+	}
+
+	if cliOpts.OutputPath == "" {
+		cliOpts.OutputPath = defaultOutputPath(inputPath)
+	}
+
+	if err := validateCLIOptions(cliOpts); err != nil {
+		return converter.ConvertOptions{}, err
+	}
+
+	return converter.ConvertOptions{
+		InputPath:         inputPath,
+		OutputPath:        cliOpts.OutputPath,
+		MaxImageWidth:     cliOpts.MaxImageWidth,
+		JPEGQuality:       cliOpts.JPEGQuality,
+		MaxImageSizeBytes: cliOpts.MaxImageSize * 1024,
+		NoImages:          cliOpts.NoImages,
+		Strict:            cliOpts.Strict,
+		Logger:            buildLogger(os.Stderr, cliOpts.LogLevel, cliOpts.LogFormat),
+	}, nil
+}
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "epub2azw3",
+		Short: "Convert EPUB files to AZW3 (Kindle) format",
+		Long: `epub2azw3 is a command-line tool that converts EPUB ebooks to
 Amazon Kindle compatible AZW3 (KF8) format.
 
 It is a standalone implementation in Go without external dependencies
 like Calibre.`,
-	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		inputPath := args[0]
-		outputPath, _ := cmd.Flags().GetString("output")
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := readCLIOptions(cmd, args)
+			if err != nil {
+				return err
+			}
 
-		if outputPath == "" {
-			outputPath = strings.TrimSuffix(inputPath, filepath.Ext(inputPath)) + ".azw3"
-		}
+			pipeline := converter.NewPipeline(opts)
+			if err := pipeline.Convert(); err != nil {
+				return fmt.Errorf("conversion failed: %w", err)
+			}
+			return nil
+		},
+	}
 
-		log.Printf("Converting: %s -> %s", inputPath, outputPath)
-
-		p := converter.NewPipeline(converter.ConvertOptions{
-			InputPath:  inputPath,
-			OutputPath: outputPath,
-		})
-
-		if err := p.Convert(); err != nil {
-			return fmt.Errorf("conversion failed: %w", err)
-		}
-
-		log.Printf("Done: %s", outputPath)
-		return nil
-	},
-}
-
-func init() {
-	rootCmd.Flags().StringP("output", "o", "", "Output file path (default: input with .azw3 extension)")
+	cmd.SetErr(os.Stderr)
+	cmd.Flags().StringP("output", "o", "", "Output file path (default: input with .azw3 extension)")
+	cmd.Flags().IntP("quality", "q", defaultJPEGQuality, "JPEG quality (60-100)")
+	cmd.Flags().Int("max-image-size", defaultMaxImageSize, "Max image size in KB")
+	cmd.Flags().Int("max-image-width", defaultMaxImageWidth, "Max image width in pixels")
+	cmd.Flags().Bool("no-images", false, "Remove all images from output")
+	cmd.Flags().StringP("log-level", "l", "info", "Log level (error/warn/info/debug)")
+	cmd.Flags().String("log-format", "text", "Log output format (text/json)")
+	cmd.Flags().Bool("strict", false, "Treat recoverable warnings as errors")
+	cmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
+	return cmd
 }
 
 func main() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := newRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/epub2azw3/main_test.go
+++ b/cmd/epub2azw3/main_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func readConvertOptionsForTest(t *testing.T, flagArgs ...string) error {
+	t.Helper()
+	cmd := newRootCmd()
+	if err := cmd.ParseFlags(flagArgs); err != nil {
+		return err
+	}
+	_, err := readCLIOptions(cmd, []string{"./input/book.epub"})
+	return err
+}
+
+func TestReadCLIOptions_Defaults(t *testing.T) {
+	cmd := newRootCmd()
+	opts, err := readCLIOptions(cmd, []string{"./input/book.epub"})
+	if err != nil {
+		t.Fatalf("readCLIOptions() error = %v", err)
+	}
+
+	if opts.OutputPath != "./input/book.azw3" {
+		t.Fatalf("OutputPath = %q, want %q", opts.OutputPath, "./input/book.azw3")
+	}
+	if opts.JPEGQuality != defaultJPEGQuality {
+		t.Fatalf("JPEGQuality = %d, want %d", opts.JPEGQuality, defaultJPEGQuality)
+	}
+	if opts.MaxImageWidth != defaultMaxImageWidth {
+		t.Fatalf("MaxImageWidth = %d, want %d", opts.MaxImageWidth, defaultMaxImageWidth)
+	}
+	if opts.MaxImageSizeBytes != defaultMaxImageSize*1024 {
+		t.Fatalf("MaxImageSizeBytes = %d, want %d", opts.MaxImageSizeBytes, defaultMaxImageSize*1024)
+	}
+	if opts.Logger == nil {
+		t.Fatal("Logger is nil, want non-nil")
+	}
+	if !opts.Logger.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("Logger should be enabled at INFO level by default")
+	}
+}
+
+func TestReadCLIOptions_CustomFlags(t *testing.T) {
+	cmd := newRootCmd()
+	if err := cmd.ParseFlags([]string{
+		"--output", "./out/custom.azw3",
+		"--quality", "90",
+		"--max-image-size", "200",
+		"--max-image-width", "720",
+		"--no-images",
+		"--log-level", "warn",
+		"--strict",
+		"--verbose",
+	}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	opts, err := readCLIOptions(cmd, []string{"./input/book.epub"})
+	if err != nil {
+		t.Fatalf("readCLIOptions() error = %v", err)
+	}
+
+	if opts.OutputPath != "./out/custom.azw3" {
+		t.Fatalf("OutputPath = %q", opts.OutputPath)
+	}
+	if opts.JPEGQuality != 90 {
+		t.Fatalf("JPEGQuality = %d", opts.JPEGQuality)
+	}
+	if opts.MaxImageSizeBytes != 200*1024 {
+		t.Fatalf("MaxImageSizeBytes = %d", opts.MaxImageSizeBytes)
+	}
+	if opts.MaxImageWidth != 720 {
+		t.Fatalf("MaxImageWidth = %d", opts.MaxImageWidth)
+	}
+	if !opts.NoImages {
+		t.Fatal("NoImages = false, want true")
+	}
+	// --verbose overrides log-level to debug
+	if !opts.Logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("Logger should be enabled at DEBUG level when --verbose is set")
+	}
+	if !opts.Strict {
+		t.Fatal("Strict = false, want true")
+	}
+}
+
+func TestReadCLIOptions_InvalidQuality(t *testing.T) {
+	err := readConvertOptionsForTest(t, "--quality", "59")
+	if err == nil || !strings.Contains(err.Error(), "--quality") {
+		t.Fatalf("expected quality validation error, got %v", err)
+	}
+
+	err = readConvertOptionsForTest(t, "--quality", "101")
+	if err == nil || !strings.Contains(err.Error(), "--quality") {
+		t.Fatalf("expected quality validation error, got %v", err)
+	}
+}
+
+func TestReadCLIOptions_InvalidMaxImageSize(t *testing.T) {
+	err := readConvertOptionsForTest(t, "--max-image-size", "0")
+	if err == nil || !strings.Contains(err.Error(), "--max-image-size") {
+		t.Fatalf("expected max-image-size validation error, got %v", err)
+	}
+}
+
+func TestReadCLIOptions_InvalidMaxImageWidth(t *testing.T) {
+	err := readConvertOptionsForTest(t, "--max-image-width", "0")
+	if err == nil || !strings.Contains(err.Error(), "--max-image-width") {
+		t.Fatalf("expected max-image-width validation error, got %v", err)
+	}
+}
+
+func TestReadCLIOptions_InvalidLogLevel(t *testing.T) {
+	err := readConvertOptionsForTest(t, "--log-level", "trace")
+	if err == nil || !strings.Contains(err.Error(), "--log-level") {
+		t.Fatalf("expected log-level validation error, got %v", err)
+	}
+}
+
+func TestReadCLIOptions_InvalidLogFormat(t *testing.T) {
+	err := readConvertOptionsForTest(t, "--log-format", "yaml")
+	if err == nil || !strings.Contains(err.Error(), "--log-format") {
+		t.Fatalf("expected log-format validation error, got %v", err)
+	}
+}
+
+func TestReadCLIOptions_JSONFormat(t *testing.T) {
+	cmd := newRootCmd()
+	if err := cmd.ParseFlags([]string{"--log-format", "json"}); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	opts, err := readCLIOptions(cmd, []string{"./input/book.epub"})
+	if err != nil {
+		t.Fatalf("readCLIOptions() error = %v", err)
+	}
+
+	if opts.Logger == nil {
+		t.Fatal("Logger is nil, want non-nil")
+	}
+	if !opts.Logger.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("Logger should be enabled at INFO level")
+	}
+}
+
+func TestBuildLogger_FormatNormalization(t *testing.T) {
+	var buf bytes.Buffer
+	logger := buildLogger(&buf, "info", "JSON")
+	logger.Info("test message")
+	// JSON format should produce JSON output (starts with '{')
+	output := buf.String()
+	if len(output) == 0 || output[0] != '{' {
+		t.Fatalf("expected JSON output for format 'JSON', got: %s", output)
+	}
+}
+
+func TestDefaultOutputPath(t *testing.T) {
+	got := defaultOutputPath("./books/sample.epub")
+	if got != "./books/sample.azw3" {
+		t.Fatalf("defaultOutputPath() = %q", got)
+	}
+}

--- a/docs/tasks/17-cli-enhancement.md
+++ b/docs/tasks/17-cli-enhancement.md
@@ -13,7 +13,10 @@ Phase 1のMVPパイプラインで実装した最小CLIを拡張し、画像品�
 
 ## 実装場所
 - 更新ファイル: `cmd/epub2azw3/main.go`
+- 更新ファイル: `internal/converter/pipeline.go`
+- 更新ファイル: `internal/converter/html.go`
 - テストファイル: `cmd/epub2azw3/main_test.go`（必要に応じて）
+- テストファイル: `internal/converter/pipeline_test.go`
 
 ## 要件
 
@@ -27,8 +30,13 @@ Phase 1のMVPパイプラインで実装した最小CLIを拡張し、画像品�
 | `--max-image-width` | | 最大画像幅（px） | 600 |
 | `--no-images` | | 画像を含めない | false |
 | `--log-level` | `-l` | ログレベル（error/warn/info/debug） | info |
+| `--log-format` | | ログ出力フォーマット（text/json） | text |
 | `--strict` | | Strictモード（警告もエラー扱い） | false |
 | `--verbose` | `-v` | 詳細出力 | false |
+
+補足:
+- `--verbose` 指定時はログレベルを `debug` として扱う
+- `--no-images` 指定時は画像レコードを生成せず、HTML中の `<img>` 要素を削除する
 
 ### 進捗表示
 - 各ステージの開始・完了を表示
@@ -56,12 +64,13 @@ Phase 1のMVPパイプラインで実装した最小CLIを拡張し、画像品�
 
 #### Strictモード
 - 回復可能エラーも致命的エラーとして扱う
-- すべての警告を収集して最後に一括表示
+- すべての警告を収集し、変換処理完了後に一括表示してエラー終了
 
 ### ログ出力
-- `log/slog` または `log` パッケージを使用
+- `log/slog` パッケージを使用
 - レベル: ERROR, WARN, INFO, DEBUG
-- フォーマット: `[LEVEL] context: message`
+- `--log-format text`（デフォルト）: `level=INFO msg="message" stage=context`（タイムスタンプなし）
+- `--log-format json`: `{"time":"...","level":"INFO","msg":"message","stage":"context"}`（タイムスタンプあり）
 
 ## データ構造
 
@@ -96,10 +105,10 @@ Phase 1のMVPパイプラインで実装した最小CLIを拡張し、画像品�
 - 通常モードで回復可能エラーが継続すること
 
 ## 完了条件
-- [ ] CLIオプション追加（cobra フラグ）
-- [ ] オプションバリデーション
-- [ ] 構造化エラーハンドリング（エラー分類）
-- [ ] Strictモード実装
-- [ ] 進捗表示
-- [ ] ログレベル切り替え
-- [ ] 全テストがパス
+- [x] CLIオプション追加（cobra フラグ）
+- [x] オプションバリデーション
+- [x] 構造化エラーハンドリング（エラー分類）
+- [x] Strictモード実装
+- [x] 進捗表示
+- [x] ログレベル切り替え
+- [x] 全テストがパス

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -117,7 +117,7 @@ PDBHeader（78 バイト固定）と RecordEntry の配列を保持。`NewPDB()`
 | # | タスク | 実装ファイル | 依存 |
 |---|--------|------------|------|
 | [16](./16-image-optimization.md) | 画像最適化 | `internal/converter/image.go` | Task 11 |
-| [17](./17-cli-enhancement.md) | CLI 強化 & エラーハンドリング | `cmd/epub2azw3/main.go` | Task 07 |
+| [17](./17-cli-enhancement.md) | CLI 強化 & エラーハンドリング | `cmd/epub2azw3/main.go`, `internal/converter/pipeline.go` | Task 07 |
 | [18](./18-concurrent-processing.md) | 並行処理 | 各パッケージ | Task 10, 16 |
 
 ### Phase 5: 高度な機能（オプション）

--- a/internal/converter/html.go
+++ b/internal/converter/html.go
@@ -209,6 +209,13 @@ func (h *HTMLBuilder) GetChapterIDs() map[string]string {
 	return result
 }
 
+// RemoveImages removes all img elements from all chapters.
+func (h *HTMLBuilder) RemoveImages() {
+	for _, chapter := range h.chapters {
+		chapter.Document.Find("img").Remove()
+	}
+}
+
 // Build generates the integrated HTML document
 func (h *HTMLBuilder) Build() (string, error) {
 	// Create a new HTML document from a template


### PR DESCRIPTION
## Summary

- CLI に詳細オプションを追加（`--quality`, `--max-image-size`, `--max-image-width`, `--no-images`, `--log-level`, `--log-format`, `--strict`, `--verbose`）
- ログ出力を `fmt.Fprintf` カスタム実装から Go 標準 `log/slog` パッケージに移行
- `--log-format` フラグ追加（text: タイムスタンプなし / json: タイムスタンプあり）
- 構造化エラーハンドリング（Fatal / Recoverable / Acceptable）と Strict モード実装
- 進捗表示（章数・画像数のカウント）

## Changes

- `cmd/epub2azw3/main.go`: CLIOptions 拡張、`buildLogger` / `parseSlogLevel` 追加、`--log-format` フラグ追加
- `internal/converter/pipeline.go`: `ConvertOptions` から `LogLevel`/`Verbose`/`ProgressWriter` を削除し `Logger *slog.Logger` に統一、`discardHandler` 追加
- `internal/converter/html.go`: `RemoveImages()` メソッド追加
- `cmd/epub2azw3/main_test.go`: 新規テスト（デフォルト値、カスタムフラグ、バリデーション、JSON フォーマット）
- `internal/converter/pipeline_test.go`: slog ベースのログ出力テスト、Strict モード・NoImages テスト追加
- `docs/tasks/17-cli-enhancement.md`: 設計書に `--log-format` と slog フォーマット説明を追加

## Test plan

- [x] `go test ./...` 全テスト通過
- [x] `go tool golangci-lint run ./...` linter クリーン
- [ ] `go run ./cmd/epub2azw3 --log-level debug testdata/test.epub` で text 出力確認
- [ ] `go run ./cmd/epub2azw3 --log-format json testdata/test.epub` で JSON 出力確認
- [ ] `go run ./cmd/epub2azw3 -v --log-format json testdata/test.epub` で verbose + JSON 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)