### PR TITLE
docs: add go install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 EPUB to AZW3 converter - a standalone Go implementation for converting EPUB ebooks to Amazon Kindle compatible AZW3 (KF8) format without external dependencies like Calibre.
 
+## Installation
+
+```bash
+go install github.com/yuanying/epub2azw3/cmd/epub2azw3@latest
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- README に `go install` によるインストール手順を追加
- `## Usage` セクションの前に `## Installation` セクションを新設

## Test plan
- [ ] `go install github.com/yuanying/epub2azw3/cmd/epub2azw3@latest` でバイナリがインストールされることを確認
- [ ] `epub2azw3 --help` でヘルプが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)