### PR TITLE
feat: add release pipeline with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go tool golangci-lint run ./...
+
+  release:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+version: 2
+
+builds:
+  - main: ./cmd/epub2azw3
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"

--- a/cmd/epub2azw3/main.go
+++ b/cmd/epub2azw3/main.go
@@ -6,11 +6,27 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/yuanying/epub2azw3/internal/converter"
 )
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func init() {
+	if version != "dev" {
+		return
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+		version = info.Main.Version
+	}
+}
 
 const (
 	defaultJPEGQuality   = 85
@@ -153,8 +169,9 @@ func readCLIOptions(cmd *cobra.Command, args []string) (converter.ConvertOptions
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "epub2azw3",
-		Short: "Convert EPUB files to AZW3 (Kindle) format",
+		Use:     "epub2azw3",
+		Version: version,
+		Short:   "Convert EPUB files to AZW3 (Kindle) format",
 		Long: `epub2azw3 is a command-line tool that converts EPUB ebooks to
 Amazon Kindle compatible AZW3 (KF8) format.
 
@@ -175,6 +192,7 @@ like Calibre.`,
 		},
 	}
 
+	cmd.SetVersionTemplate(fmt.Sprintf("epub2azw3 %s (commit: %s, built: %s)\n", version, commit, date))
 	cmd.SetErr(os.Stderr)
 	cmd.Flags().StringP("output", "o", "", "Output file path (default: input with .azw3 extension)")
 	cmd.Flags().IntP("quality", "q", defaultJPEGQuality, "JPEG quality (60-100)")


### PR DESCRIPTION
## Summary
- GoReleaser + GitHub Actions によるリリース自動化パイプラインを追加
- `v*` タグプッシュで test/lint 実行後、クロスコンパイル済みバイナリを GitHub Release に公開
- `--version` フラグでバージョン情報（version, commit, date）を表示可能に

## 変更内容
- `cmd/epub2azw3/main.go`: バージョン変数（ldflags 注入）と `--version` フラグの追加
- `.goreleaser.yaml`: ビルドターゲット（linux/darwin/windows × amd64/arm64）、アーカイブ、チェックサム設定
- `.github/workflows/release.yml`: test/lint → release の依存ジョブ構成

## Test plan
- [x] `go build -ldflags "-X main.version=test" -o epub2azw3 ./cmd/epub2azw3 && ./epub2azw3 --version` でバージョン表示を確認
- [x] `go test ./...` 全テストパス
- [x] `go tool golangci-lint run ./...` lint パス
- [ ] タグ `v0.1.0` をプッシュし、GitHub Actions のリリースワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)